### PR TITLE
fix: send information on error

### DIFF
--- a/lib/approveAndMerge.js
+++ b/lib/approveAndMerge.js
@@ -10,16 +10,25 @@ const {
 
 const DEPENDABOT = 'dependabot[bot]'
 
+const ERROR_REPO_NOT_FOUND = 'no repository accessible with provided token - see https://github.com/fastify/github-action-merge-dependabot#usage'
+const ERROR_APP_NOT_FOUND = 'no installation found for app on repo - see https://github.com/fastify/github-action-merge-dependabot#usage'
+const ERROR_PULL_REQUEST_NOT_FOUND = 'pull request not found'
+const MESSAGE_NO_DEPENDABOT_PR = 'not a dependabot PR, skipping'
+const MESSAGE_APPROVING_ONLY = 'approving only'
+const MESSAGE_PACKAGE_IS_EXCLUDED = 'is excluded, skipping'
+
 async function approveAndMerge(
   githubToken,
   appJWT,
   pullRequestNumber,
   options
 ) {
-  const [repository] = await getInstallationRepositories(githubToken)
+  let repository, installation, accessToken, pullRequest
 
-  if (!repository) {
-    throw new Error('no repository accessible with provided token')
+  try {
+    [repository] = await getInstallationRepositories(githubToken)
+  } catch (error) {
+    throw new Error(ERROR_REPO_NOT_FOUND)
   }
 
   const {
@@ -27,39 +36,41 @@ async function approveAndMerge(
     owner: { login: owner },
   } = repository
 
-  const installation = await getRepositoryInstallation(owner, repo, appJWT)
-
-  if (!installation) {
-    throw new Error('no installation found for app on repo')
+  try {
+    installation = await getRepositoryInstallation(owner, repo, appJWT)
+  } catch (error) {
+    throw new Error(ERROR_APP_NOT_FOUND)
   }
 
-  const { token: accessToken } = await createInstallationAccessToken(
-    installation,
-    appJWT
-  )
+  try {
+    const access = await createInstallationAccessToken(installation, appJWT)
+    accessToken = access.token
+  } catch (error) {
+    throw new Error(ERROR_APP_NOT_FOUND)
+  }
 
-  const pullRequest = await getPullRequest(
-    owner,
-    repo,
-    pullRequestNumber,
-    accessToken
-  )
-
-  if (!pullRequest) {
-    throw new Error('pull request not found')
+  try {
+    pullRequest = await getPullRequest(
+      owner,
+      repo,
+      pullRequestNumber,
+      accessToken
+    )
+  } catch (error) {
+    throw new Error(ERROR_PULL_REQUEST_NOT_FOUND)
   }
 
   const isDependabotPR = pullRequest.user.login === DEPENDABOT
 
   if (!isDependabotPR) {
-    return 'Not dependabot PR, skipping'
+    return MESSAGE_NO_DEPENDABOT_PR
   }
 
   // dependabot branch names are in format "dependabot/npm_and_yarn/pkg-0.0.1"
   const pkgName = pullRequest.head.ref.split('/').pop().split('-').shift()
 
   if (options.excludePackages.includes(pkgName)) {
-    return `${pkgName} is excluded, skipping`
+    return `${pkgName} ${MESSAGE_PACKAGE_IS_EXCLUDED}`
   }
 
   await approvePullRequest(
@@ -71,7 +82,7 @@ async function approveAndMerge(
   )
 
   if (options.approveOnly) {
-    return 'Approving only'
+    return MESSAGE_APPROVING_ONLY
   }
 
   return mergePullRequest(

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Unauthorized } = require('http-errors')
+const { Unauthorized, BadRequest } = require('http-errors')
 const S = require('fluent-json-schema')
 
 const approveAndMerge = require('./approveAndMerge')
@@ -36,11 +36,15 @@ module.exports = async (fastify, options) => {
 
     const appJWT = createAppJWT(options.APP_ID, options.PRIVATE_KEY)
 
-    return approveAndMerge(githubToken, appJWT, pullRequestNumber, {
-      approveOnly,
-      excludePackages,
-      approveComment,
-      mergeMethod,
-    })
+    try {
+      return await approveAndMerge(githubToken, appJWT, pullRequestNumber, {
+        approveOnly,
+        excludePackages,
+        approveComment,
+        mergeMethod,
+      })
+    } catch (error) {
+      throw new BadRequest(error.message)
+    }
   })
 }


### PR DESCRIPTION
See issue https://github.com/fastify/github-action-merge-dependabot/issues/28

The error message will be

![automerge error](https://user-images.githubusercontent.com/5823031/115558920-7e7e8a80-a2b3-11eb-846a-d5c766b24e90.png)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
