### PR TITLE
chore: log repository name where action runs

### DIFF
--- a/lib/approveAndMerge.js
+++ b/lib/approveAndMerge.js
@@ -11,6 +11,7 @@ const {
 const DEPENDABOT = 'dependabot[bot]'
 
 async function approveAndMerge(
+  request,
   githubToken,
   appJWT,
   pullRequestNumber,
@@ -22,6 +23,8 @@ async function approveAndMerge(
     name: repo,
     owner: { login: owner },
   } = repository
+
+  request.log.info(`Running on repository ${owner}/${repo}`)
 
   const installation = await getRepositoryInstallation(owner, repo, appJWT)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -37,14 +37,23 @@ module.exports = async (fastify, options) => {
     const appJWT = createAppJWT(options.APP_ID, options.PRIVATE_KEY)
 
     try {
-      return await approveAndMerge(githubToken, appJWT, pullRequestNumber, {
-        approveOnly,
-        excludePackages,
-        approveComment,
-        mergeMethod,
-      })
+      return await approveAndMerge(
+        req,
+        githubToken,
+        appJWT,
+        pullRequestNumber,
+        {
+          approveOnly,
+          excludePackages,
+          approveComment,
+          mergeMethod,
+        }
+      )
     } catch (error) {
-      throw new BadRequest('See https://github.com/fastify/github-action-merge-dependabot#usage - ' + error.message)
+      throw new BadRequest(
+        'See https://github.com/fastify/github-action-merge-dependabot#usage - ' +
+          error.message
+      )
     }
   })
 }

--- a/test/approveAndMerge.test.js
+++ b/test/approveAndMerge.test.js
@@ -1,10 +1,17 @@
 'use strict'
 
 const tap = require('tap')
-const proxyquire = require("proxyquire")
+const proxyquire = require('proxyquire')
 const assert = require('assert')
 
-let mockCreateAppJWT, mockGetInstallationRepositories, mockCreateInstallationAccessToken, mockGetRepositoryInstallation, mockGetPullRequest, mockApprovePullRequest, mockMergePullRequest
+let mockRequest,
+  mockCreateAppJWT,
+  mockGetInstallationRepositories,
+  mockCreateInstallationAccessToken,
+  mockGetRepositoryInstallation,
+  mockGetPullRequest,
+  mockApprovePullRequest,
+  mockMergePullRequest
 
 const approveAndMerge = proxyquire('../lib/approveAndMerge', {
   './github.js': {
@@ -15,22 +22,26 @@ const approveAndMerge = proxyquire('../lib/approveAndMerge', {
     getPullRequest: () => mockGetPullRequest(),
     approvePullRequest: () => mockApprovePullRequest(),
     mergePullRequest: () => mockMergePullRequest(),
-  }
+  },
 })
 
 tap.test('approveAndMerge function', t => {
-
   t.beforeEach(() => {
-    mockCreateAppJWT = (appId, privateKey) => { }
-    mockGetInstallationRepositories = async (token) => [{ name: 'the-repo', owner: { login: 'the-owner' } }]
-    mockCreateInstallationAccessToken = async (installation, appJWT) => ({ token: 'the-access-token' })
-    mockGetRepositoryInstallation = async (owner, repo, appJWT) => { }
-    mockGetPullRequest = async (owner, repo, pullRequestNumber, accessToken) => ({
-      user: { login: 'dependabot[bot]' },
-      head: { ref: "dependabot/npm_and_yarn/pkg-0.0.1" }
+    mockRequest = { log: { info: () => {} } }
+    mockCreateAppJWT = () => {}
+    mockGetInstallationRepositories = async () => [
+      { name: 'the-repo', owner: { login: 'the-owner' } },
+    ]
+    mockCreateInstallationAccessToken = async () => ({
+      token: 'the-access-token',
     })
-    mockApprovePullRequest = async (owner, repo, pullRequestNumber, accessToken, approveComment) => { }
-    mockMergePullRequest = async (owner, repo, pullRequestNumber, accessToken, mergeMethod) => { }
+    mockGetRepositoryInstallation = async () => {}
+    mockGetPullRequest = async () => ({
+      user: { login: 'dependabot[bot]' },
+      head: { ref: 'dependabot/npm_and_yarn/pkg-0.0.1' },
+    })
+    mockApprovePullRequest = async () => {}
+    mockMergePullRequest = async () => {}
   })
 
   t.plan(5)
@@ -41,13 +52,21 @@ tap.test('approveAndMerge function', t => {
     const pullRequestNumber = 123
     const options = { excludePackages: [] }
 
-    await approveAndMerge(githubToken, appJWT, pullRequestNumber, options)
+    await approveAndMerge(
+      mockRequest,
+      githubToken,
+      appJWT,
+      pullRequestNumber,
+      options
+    )
 
     t.pass()
   })
 
   t.test('should throw error on missing app installation in repo', async t => {
-    mockGetRepositoryInstallation = () => { assert(false, '{"message":"Integration not found"}') }
+    mockGetRepositoryInstallation = () => {
+      assert(false, '{"message":"Integration not found"}')
+    }
 
     const githubToken = 'the-github-token'
     const appJWT = 'jwt-token'
@@ -55,26 +74,44 @@ tap.test('approveAndMerge function', t => {
     const options = { excludePackages: [] }
 
     try {
-      await approveAndMerge(githubToken, appJWT, pullRequestNumber, options)
+      await approveAndMerge(
+        mockRequest,
+        githubToken,
+        appJWT,
+        pullRequestNumber,
+        options
+      )
       t.fail('approveAndMerge is suppose to throw an error')
     } catch (error) {
       t.match(error.message, /Integration not found/)
     }
   })
 
-  t.test('should return a message if the author of the PR is not dependabot', async t => {
-    mockGetPullRequest = async (owner, repo, pullRequestNumber, accessToken) => ({
-      user: { login: 'spambot' },
-      head: { ref: "dependabot/npm_and_yarn/pkg-0.0.1" }
-    })
+  t.test(
+    'should return a message if the author of the PR is not dependabot',
+    async t => {
+      mockGetPullRequest = async () => ({
+        user: { login: 'spambot' },
+        head: { ref: 'dependabot/npm_and_yarn/pkg-0.0.1' },
+      })
 
-    const githubToken = 'the-github-token'
-    const appJWT = 'jwt-token'
-    const pullRequestNumber = 123
-    const options = { excludePackages: [] }
+      const githubToken = 'the-github-token'
+      const appJWT = 'jwt-token'
+      const pullRequestNumber = 123
+      const options = { excludePackages: [] }
 
-    t.equal(await approveAndMerge(githubToken, appJWT, pullRequestNumber, options), 'Not dependabot PR, skipping')
-  })
+      t.equal(
+        await approveAndMerge(
+          mockRequest,
+          githubToken,
+          appJWT,
+          pullRequestNumber,
+          options
+        ),
+        'Not dependabot PR, skipping'
+      )
+    }
+  )
 
   t.test('should return a message if package has to be skipped', async t => {
     const githubToken = 'the-github-token'
@@ -82,7 +119,16 @@ tap.test('approveAndMerge function', t => {
     const pullRequestNumber = 123
     const options = { excludePackages: ['pkg'] }
 
-    t.equal(await approveAndMerge(githubToken, appJWT, pullRequestNumber, options), 'pkg is excluded, skipping')
+    t.equal(
+      await approveAndMerge(
+        mockRequest,
+        githubToken,
+        appJWT,
+        pullRequestNumber,
+        options
+      ),
+      'pkg is excluded, skipping'
+    )
   })
 
   t.test('should return a message on approve only option', async t => {
@@ -91,6 +137,15 @@ tap.test('approveAndMerge function', t => {
     const pullRequestNumber = 123
     const options = { excludePackages: [], approveOnly: true }
 
-    t.equal(await approveAndMerge(githubToken, appJWT, pullRequestNumber, options), 'Approving only')
+    t.equal(
+      await approveAndMerge(
+        mockRequest,
+        githubToken,
+        appJWT,
+        pullRequestNumber,
+        options
+      ),
+      'Approving only'
+    )
   })
 })


### PR DESCRIPTION
Logs the name of the repository where the action runs. We need this so we can identify the repos which are still running on the old version of the action and application which we want to decommission before turning it off.

Related to #22 

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
